### PR TITLE
Add keyboard shortcut (Alt+U) to toggle extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,27 @@
+// Cinefill - Background Service Worker
+
+// Listen for keyboard shortcut command
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'toggle-cinefill') {
+    toggleExtension();
+  }
+});
+
+// Toggle the extension state
+async function toggleExtension() {
+  const result = await chrome.storage.local.get(['enabled']);
+  const newState = !result.enabled;
+
+  await chrome.storage.local.set({ enabled: newState });
+
+  // Send message to content script in active tab
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (tab?.id) {
+    chrome.tabs.sendMessage(tab.id, {
+      action: 'toggle',
+      enabled: newState
+    }).catch(() => {
+      // Content script not loaded on this page
+    });
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,21 @@
 {
   "manifest_version": 3,
   "name": "Cinefill",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Remove letterbox bars and fill your ultrawide screen on streaming services",
   "permissions": ["storage", "activeTab"],
+  "commands": {
+    "toggle-cinefill": {
+      "suggested_key": {
+        "default": "Alt+U",
+        "mac": "Alt+U"
+      },
+      "description": "Toggle Cinefill on/off"
+    }
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
   "host_permissions": [
     "*://*.max.com/*",
     "*://*.hbomax.com/*",


### PR DESCRIPTION
## Summary
- Add `commands` section to manifest.json with Alt+U default shortcut
- Create `background.js` service worker to handle command
- Toggle sends message to content script in active tab

## Test plan
- [ ] Load extension in Chrome
- [ ] Press Alt+U while on a streaming site
- [ ] Verify extension toggles on/off
- [ ] Check chrome://extensions/shortcuts to customize shortcut

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)