### PR TITLE
Add badge indicator showing ON/OFF state

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,38 @@
 // Cinefill - Background Service Worker
 
+// Badge colors
+const BADGE_ON_COLOR = '#34C759';  // Green
+const BADGE_OFF_COLOR = '#8E8E93'; // Gray
+
+// Update badge based on state
+function updateBadge(enabled) {
+  chrome.action.setBadgeText({ text: enabled ? 'ON' : 'OFF' });
+  chrome.action.setBadgeBackgroundColor({
+    color: enabled ? BADGE_ON_COLOR : BADGE_OFF_COLOR
+  });
+}
+
+// Initialize badge on startup
+chrome.runtime.onStartup.addListener(() => {
+  chrome.storage.local.get(['enabled'], (result) => {
+    updateBadge(result.enabled || false);
+  });
+});
+
+// Initialize badge on install
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.get(['enabled'], (result) => {
+    updateBadge(result.enabled || false);
+  });
+});
+
+// Listen for storage changes to update badge
+chrome.storage.onChanged.addListener((changes, namespace) => {
+  if (namespace === 'local' && changes.enabled) {
+    updateBadge(changes.enabled.newValue);
+  }
+});
+
 // Listen for keyboard shortcut command
 chrome.commands.onCommand.addListener((command) => {
   if (command === 'toggle-cinefill') {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Cinefill",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Remove letterbox bars and fill your ultrawide screen on streaming services",
   "permissions": ["storage", "activeTab"],
   "commands": {


### PR DESCRIPTION
## Summary
- Show "ON" with green badge (#34C759) when enabled
- Show "OFF" with gray badge (#8E8E93) when disabled
- Update badge on startup, install, and state changes
- Listens to `chrome.storage.onChanged` for real-time updates

## Test plan
- [ ] Load extension, verify badge shows "OFF" initially
- [ ] Enable extension, verify badge shows "ON" in green
- [ ] Disable extension, verify badge shows "OFF" in gray
- [ ] Use keyboard shortcut, verify badge updates

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)