### PR TITLE
Add per-site zoom memory

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Cinefill",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Remove letterbox bars and fill your ultrawide screen on streaming services",
   "permissions": ["storage", "activeTab"],
   "commands": {

--- a/popup.html
+++ b/popup.html
@@ -34,7 +34,15 @@
       </div>
     </div>
 
-    <p class="hint">Works on max.com</p>
+    <div class="site-section" id="siteSection" style="display: none;">
+      <div class="site-info">
+        <span class="site-label">Current site:</span>
+        <span class="site-domain" id="siteDomain"></span>
+      </div>
+      <button class="save-site-btn" id="saveSiteBtn">Save for this site</button>
+    </div>
+
+    <p class="hint">Works on streaming sites</p>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -216,6 +216,56 @@ input[type="range"]::-webkit-slider-thumb:hover {
   color: #fff;
 }
 
+/* Site Section */
+.site-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+}
+
+.site-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.site-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.site-domain {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.save-site-btn {
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.save-site-btn:hover {
+  background: var(--accent-hover);
+}
+
+.save-site-btn.saved {
+  background: #34C759;
+}
+
 /* Hint */
 .hint {
   font-size: 11px;


### PR DESCRIPTION
## Summary
- Extract domain from current URL in content script
- Load site-specific settings before falling back to global settings
- Add site indicator showing current domain in popup
- Add "Save for this site" button to persist per-site settings
- Store site settings in `siteSettings` object keyed by domain

## Test plan
- [ ] Navigate to max.com, set zoom to 1.4x, click "Save for this site"
- [ ] Navigate to netflix.com, set zoom to 1.2x, click "Save for this site"
- [ ] Return to max.com, verify zoom is 1.4x
- [ ] Return to netflix.com, verify zoom is 1.2x
- [ ] Verify "Saved!" feedback appears on button click

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)